### PR TITLE
Fix SNS and KMS Policies

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,18 +1,4 @@
 
 data "aws_caller_identity" "current" {}
 
-data "aws_iam_policy_document" "this" {
-  dynamic "statement" {
-    for_each = local.kms_allowed_accounts
-    content {
-      sid    = "Enable IAM Permissions from ${statement.value}"
-      effect = "Allow"
-      principals {
-        identifiers = ["arn:aws:iam::${statement.value}:root"]
-        type        = "AWS"
-      }
-      actions   = ["kms:*"]
-      resources = ["*"]
-    }
-  }
-}
+data "aws_region" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,8 @@ resource "aws_sns_topic" "guardduty_findings_info" {
   count             = var.enable_sns ? 1 : 0
   kms_master_key_id = aws_kms_key.this[0].key_id
   name              = "guardduty-findings-info"
+  policy            = data.aws_iam_policy_document.sns_access_policy.json
+
 
   tags = merge(local.common_tags)
 }
@@ -11,6 +13,8 @@ resource "aws_sns_topic" "guardduty_findings_warning" {
   count             = var.enable_sns ? 1 : 0
   kms_master_key_id = aws_kms_key.this[0].key_id
   name              = "guardduty-findings-warning"
+  policy            = data.aws_iam_policy_document.sns_access_policy.json
+
 
   tags = merge(local.common_tags)
 }
@@ -19,6 +23,7 @@ resource "aws_sns_topic" "guardduty_findings_critical" {
   count             = var.enable_sns ? 1 : 0
   kms_master_key_id = aws_kms_key.this[0].key_id
   name              = "guardduty-findings-critical"
+  policy            = data.aws_iam_policy_document.sns_access_policy.json
 
   tags = merge(local.common_tags)
 }
@@ -85,4 +90,46 @@ resource "aws_kms_alias" "this" {
   count         = var.enable_sns ? 1 : 0
   name          = "alias/guard-duty-findings-SNS-topics"
   target_key_id = aws_kms_key.this[0].key_id
+}
+
+### Supporting Resources
+data "aws_iam_policy_document" "sns_access_policy" {
+  version = "2008-10-17"
+  statement {
+    sid    = "__default_statement_ID"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "SNS:GetTopicAttributes",
+      "SNS:SetTopicAttributes",
+      "SNS:AddPermission",
+      "SNS:RemovePermission",
+      "SNS:DeleteTopic",
+      "SNS:Subscribe",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:Publish"
+    ]
+    resources = ["arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:guardduty-findings-*"]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+  statement {
+    sid    = "TrustCWEToPublishEvents"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    actions = [
+      "SNS:Publish"
+    ]
+    resources = ["arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:guardduty-findings-*"]
+  }
+
 }


### PR DESCRIPTION
## Change description

> IAM now requires explicit permissions for services to use other services.  KMS key policy for SNS-encrypting key modified to allow use by SNS and Events services.  SNS access policy modified to allow Events service to publish messages.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
